### PR TITLE
Use Memory Type Variable Instead of Storage Type Variable in Event to Save Gas

### DIFF
--- a/contracts/USDPImplementationV3.sol
+++ b/contracts/USDPImplementationV3.sol
@@ -295,7 +295,7 @@ contract USDPImplementationV3 {
         require(_proposedOwner != address(0), "cannot transfer ownership to address zero");
         require(msg.sender != _proposedOwner, "caller already is owner");
         proposedOwner = _proposedOwner;
-        emit OwnershipTransferProposed(owner, proposedOwner);
+        emit OwnershipTransferProposed(owner, _proposedOwner);
     }
     /**
      * @dev Allows the current owner or proposed owner to cancel transferring control of the contract to a proposedOwner

--- a/contracts/archive/PAXImplementationV2.sol
+++ b/contracts/archive/PAXImplementationV2.sol
@@ -293,7 +293,7 @@ contract PAXImplementationV2 {
     require(_proposedOwner != address(0), "cannot transfer ownership to address zero");
     require(msg.sender != _proposedOwner, "caller already is owner");
     proposedOwner = _proposedOwner;
-    emit OwnershipTransferProposed(owner, proposedOwner);
+    emit OwnershipTransferProposed(owner, _proposedOwner);
   }
   /**
    * @dev Allows the current owner or proposed owner to cancel transferring control of the contract to a proposedOwner

--- a/flattened/PAXImplementationV2.sol
+++ b/flattened/PAXImplementationV2.sol
@@ -323,7 +323,7 @@ contract PAXImplementationV2 {
     require(_proposedOwner != address(0), "cannot transfer ownership to address zero");
     require(msg.sender != _proposedOwner, "caller already is owner");
     proposedOwner = _proposedOwner;
-    emit OwnershipTransferProposed(owner, proposedOwner);
+    emit OwnershipTransferProposed(owner, _proposedOwner);
   }
   /**
    * @dev Allows the current owner or proposed owner to cancel transferring control of the contract to a proposedOwner

--- a/flattened/USDPImplementationV3.sol
+++ b/flattened/USDPImplementationV3.sol
@@ -326,7 +326,7 @@ contract USDPImplementationV3 {
         require(_proposedOwner != address(0), "cannot transfer ownership to address zero");
         require(msg.sender != _proposedOwner, "caller already is owner");
         proposedOwner = _proposedOwner;
-        emit OwnershipTransferProposed(owner, proposedOwner);
+        emit OwnershipTransferProposed(owner, _proposedOwner);
     }
     /**
      * @dev Allows the current owner or proposed owner to cancel transferring control of the contract to a proposedOwner


### PR DESCRIPTION
Hi, we are a research group on programming languages and software engineering. We recently have conducted a systematic study about Solidity event usage, evolution, and impact, and we are attempting to build a tool to improve the practice of Solidity event use based on our findings. We have tried our prototype tool on some of the most popular GitHub Solidity repositories, and for your repository, we find a potential optimization of gas consumption arisen from event use.  

The point is that when we use emit operation to store the value of a certain variable, `local memory type variable` would be preferable to `storage type (state) variable` if they hold the same value. The reason is that an extra SLOAD operation would be needed to access the variable if it is storage type, and the SLOAD operation costs 800 gas.

For your repository, we find that several event uses can be improved.